### PR TITLE
Add log levels & remove duplicated exposed objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,8 @@ set(WHICH_PYTHON3 "python3${Python3_VERSION_MINOR}" CACHE STRING "Python3 versio
 find_package(
   Boost
   COMPONENTS ${WHICH_PYTHON3} filesystem unit_test_framework
-  REQUIRED)
+  REQUIRED
+  )
 
 set(EAGLE_MPC_YAML_DIR "${eagle_mpc_SOURCE_DIR}/yaml")
 
@@ -50,6 +51,20 @@ else()
 endif()
 
 configure_file(${eagle_mpc_SOURCE_DIR}/config/path.py.in path.py)
+
+# Define level of verbosity
+# VERBOSE_LEVEL
+# 0: errors messages
+# 1: errors & warnings
+# 2: errors, warnings & info
+#
+# VERBOSE_DEBUG: to activate debug messages
+set(VERBOSE_LEVEL 2)
+set(VERBOSE_DEBUG 0)
+
+
+add_compile_definitions(VERBOSE_DEBUG=${VERBOSE_DEBUG})
+add_compile_definitions(VERBOSE_LEVEL=${VERBOSE_LEVEL})
 
 add_subdirectory(src)
 if(WITH_EXAMPLES)

--- a/bindings/python/eagle_mpc/sbfddp.hpp
+++ b/bindings/python/eagle_mpc/sbfddp.hpp
@@ -26,7 +26,6 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SolverSbFDDP_solves, SolverSbFDDP::solve,
 void exposeSolverSbFDDP()
 {
     bp::register_ptr_to_python<boost::shared_ptr<SolverSbFDDP>>();
-    bp::register_ptr_to_python<boost::shared_ptr<crocoddyl::SquashingModelSmoothSat>>();
 
     const std::vector<Eigen::VectorXd>& (SolverSbFDDP::*get_controls)() const = &SolverSbFDDP::get_us;
     const std::vector<Eigen::VectorXd>& (SolverSbFDDP::*get_controls_squash)() const =

--- a/bindings/python/eagle_mpc/trajectory.hpp
+++ b/bindings/python/eagle_mpc/trajectory.hpp
@@ -26,8 +26,6 @@ void exposeTrajectory()
     StdVectorPythonVisitor<boost::shared_ptr<Stage>, std::allocator<boost::shared_ptr<Stage>>, true>::expose(
         "StdVec_Stages");
 
-    bp::register_ptr_to_python<boost::shared_ptr<crocoddyl::StateMultibody>>();
-    bp::register_ptr_to_python<boost::shared_ptr<crocoddyl::ActuationModelMultiCopterBase>>();
     bp::register_ptr_to_python<boost::shared_ptr<pinocchio::Model>>();
 
     boost::shared_ptr<crocoddyl::ShootingProblem> (Trajectory::*create_problem_no_args)() const =

--- a/include/eagle_mpc/utils/log.hpp
+++ b/include/eagle_mpc/utils/log.hpp
@@ -8,28 +8,89 @@
 #ifndef EAGLE_MPC_UTILS_LOG_HPP_
 #define EAGLE_MPC_UTILS_LOG_HPP_
 
-#include <iostream>
+#include <stdio.h>
+#include <utility>
+
+#define ANSI_COLOR_RED "\x1b[31m"
+#define ANSI_COLOR_GREEN "\x1b[32m"
+#define ANSI_COLOR_YELLOW "\x1b[33m"
+#define ANSI_COLOR_BLUE "\x1b[34m"
+#define ANSI_COLOR_MAGENTA "\x1b[35m"
+#define ANSI_COLOR_CYAN "\x1b[36m"
+#define ANSI_COLOR_RESET "\x1b[0m \n"
 
 namespace eagle_mpc
 {
-class Log
+void log();
+
+template <typename First, typename... Rest>
+void log(First&& first, Rest&&... rest)
 {
-    public:
-    Log(const std::string &funcName) { std::cout << funcName; }
+    std::cout << std::forward<First>(first);
+    log(std::forward<Rest>(rest)...);
+}
 
-    template <class T>
-    Log &operator<<(const T &v)
-    {
-        std::cout << v;
-        return *this;
+#if VERBOSE_LEVEL == 1
+#define EMPC_ERROR(...)           \
+    {                             \
+        printf(ANSI_COLOR_RED);   \
+        log(__VA_ARGS__);         \
+        printf(ANSI_COLOR_RESET); \
     }
+#define EMPC_WARN(...)             \
+    {                              \
+        printf(ANSI_COLOR_YELLOW); \
+        log(__VA_ARGS__);          \
+        printf(ANSI_COLOR_RESET);  \
+    }
+#define EMPC_INFO(...) \
+    {                  \
+    }
+#elif VERBOSE_LEVEL == 2
+#define EMPC_ERROR(...)           \
+    {                             \
+        printf(ANSI_COLOR_RED);   \
+        log(__VA_ARGS__);         \
+        printf(ANSI_COLOR_RESET); \
+    }
+#define EMPC_WARN(...)             \
+    {                              \
+        printf(ANSI_COLOR_YELLOW); \
+        log(__VA_ARGS__);          \
+        printf(ANSI_COLOR_RESET);  \
+    }
+#define EMPC_INFO(...)            \
+    {                             \
+        printf(ANSI_COLOR_CYAN);  \
+        log(__VA_ARGS__);         \
+        printf(ANSI_COLOR_RESET); \
+    }
+#else
+#define EMPC_ERROR(...)           \
+    {                             \
+        printf(ANSI_COLOR_RED);   \
+        log(__VA_ARGS__);         \
+        printf(ANSI_COLOR_RESET); \
+    }
+#define EMPC_WARN(...) \
+    {                  \
+    }
+#define EMPC_INFO(...) \
+    {                  \
+    }
+#endif
 
-    ~Log() { std::cout << "\033[0m" << std::endl; }
-};
-
-#define EMPC_INFO Log("\033[0;36m[EAGLE_MPC INFO]: ")  // 36==cyan
-#define EMPC_WARN Log("\033[0;33m[EAGLE_MPC WARN]:")   // 33==yellow
-#define EMPC_ERROR Log("\033[0;31m[EAGLE_MPC ERROR]")  // 31==red
+#if VERBOSE_DEBUG == 1
+#define EMPC_DEBUG(...)           \
+    {                             \
+        log(__VA_ARGS__);         \
+        printf(ANSI_COLOR_RESET); \
+    }
+#else
+#define EMPC_DEBUG(...) \
+    {                   \
+    }
+#endif
 
 }  // namespace eagle_mpc
 #endif

--- a/include/eagle_mpc/utils/log.hpp
+++ b/include/eagle_mpc/utils/log.hpp
@@ -27,9 +27,9 @@ class Log
     ~Log() { std::cout << "\033[0m" << std::endl; }
 };
 
-#define MMPC_INFO Log("\033[0;36m[EAGLE_MPC INFO]: ")  // 36==cyan
-#define MMPC_WARN Log("\033[0;33m[EAGLE_MPC WARN]:")   // 33==yellow
-#define MMPC_ERROR Log("\033[0;31m[EAGLE_MPC ERROR]")  // 31==red
+#define EMPC_INFO Log("\033[0;36m[EAGLE_MPC INFO]: ")  // 36==cyan
+#define EMPC_WARN Log("\033[0;33m[EAGLE_MPC WARN]:")   // 33==yellow
+#define EMPC_ERROR Log("\033[0;31m[EAGLE_MPC ERROR]")  // 31==red
 
 }  // namespace eagle_mpc
 #endif

--- a/src/factory/activation.cpp
+++ b/src/factory/activation.cpp
@@ -25,7 +25,7 @@ boost::shared_ptr<crocoddyl::ActivationModelAbstract> ActivationModelFactory::cr
     try {
         name = server->getParam<std::string>(path_to_cost + "activation");
     } catch (const std::exception& e) {
-        MMPC_WARN << e.what() << " Set to quadratic activation.";
+        EMPC_WARN << e.what() << " Set to quadratic activation.";
         name = "ActivationModelQuad";
     }
 
@@ -39,7 +39,7 @@ boost::shared_ptr<crocoddyl::ActivationModelAbstract> ActivationModelFactory::cr
             try {
                 weights = converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_cost + "weights"));
             } catch (const std::exception& e) {
-                MMPC_WARN << e.what() << " Set to a unitary vector";
+                EMPC_WARN << e.what() << " Set to a unitary vector";
                 weights = Eigen::VectorXd::Ones(nr);
             }
 
@@ -75,7 +75,7 @@ boost::shared_ptr<crocoddyl::ActivationModelAbstract> ActivationModelFactory::cr
             try {
                 weights = converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_cost + "weights"));
             } catch (const std::exception& e) {
-                MMPC_WARN << e.what() << " Set to a unitary vector";
+                EMPC_WARN << e.what() << " Set to a unitary vector";
                 weights = Eigen::VectorXd::Ones(nr);
             }
 

--- a/src/factory/activation.cpp
+++ b/src/factory/activation.cpp
@@ -25,7 +25,7 @@ boost::shared_ptr<crocoddyl::ActivationModelAbstract> ActivationModelFactory::cr
     try {
         name = server->getParam<std::string>(path_to_cost + "activation");
     } catch (const std::exception& e) {
-        EMPC_WARN << e.what() << " Set to quadratic activation.";
+        EMPC_DEBUG(e.what(), " Set to quadratic activation.");
         name = "ActivationModelQuad";
     }
 
@@ -39,7 +39,7 @@ boost::shared_ptr<crocoddyl::ActivationModelAbstract> ActivationModelFactory::cr
             try {
                 weights = converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_cost + "weights"));
             } catch (const std::exception& e) {
-                EMPC_WARN << e.what() << " Set to a unitary vector";
+                EMPC_DEBUG(e.what()," Set to a unitary vector");
                 weights = Eigen::VectorXd::Ones(nr);
             }
 
@@ -75,7 +75,7 @@ boost::shared_ptr<crocoddyl::ActivationModelAbstract> ActivationModelFactory::cr
             try {
                 weights = converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_cost + "weights"));
             } catch (const std::exception& e) {
-                EMPC_WARN << e.what() << " Set to a unitary vector";
+                EMPC_DEBUG(e.what(), " Set to a unitary vector");
                 weights = Eigen::VectorXd::Ones(nr);
             }
 

--- a/src/factory/contacts.cpp
+++ b/src/factory/contacts.cpp
@@ -42,7 +42,7 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModelFactory::create(
             try {
                 gains = converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_contact + "gains"));
             } catch (const std::exception& e) {
-                MMPC_WARN << e.what() << " Set to the zero gains vector";
+                EMPC_WARN << e.what() << " Set to the zero gains vector";
                 gains = Eigen::Vector2d::Zero();
             }
 
@@ -70,7 +70,7 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModelFactory::create(
             try {
                 gains = converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_contact + "gains"));
             } catch (const std::exception& e) {
-                MMPC_WARN << e.what() << " Set to the zero gains vector";
+                EMPC_WARN << e.what() << " Set to the zero gains vector";
                 gains = Eigen::Vector2d::Zero();
             }
 

--- a/src/factory/contacts.cpp
+++ b/src/factory/contacts.cpp
@@ -42,7 +42,7 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModelFactory::create(
             try {
                 gains = converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_contact + "gains"));
             } catch (const std::exception& e) {
-                EMPC_WARN << e.what() << " Set to the zero gains vector";
+                EMPC_DEBUG(e.what(), " Set to the zero gains vector");
                 gains = Eigen::Vector2d::Zero();
             }
 
@@ -70,7 +70,7 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModelFactory::create(
             try {
                 gains = converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_contact + "gains"));
             } catch (const std::exception& e) {
-                EMPC_WARN << e.what() << " Set to the zero gains vector";
+                EMPC_DEBUG(e.what(), "  Set to the zero gains vector");
                 gains = Eigen::Vector2d::Zero();
             }
 

--- a/src/factory/cost.cpp
+++ b/src/factory/cost.cpp
@@ -42,7 +42,7 @@ boost::shared_ptr<crocoddyl::CostModelResidual> CostModelFactory::create(
                 reference =
                     converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_cost + "reference"));
             } catch (const std::exception& e) {
-                MMPC_WARN << e.what() << " Set to the zero state vector";
+                EMPC_WARN << e.what() << " Set to the zero state vector";
                 reference = state->zero();
             }
             if (reference.size() != state->get_nx()) {
@@ -61,7 +61,7 @@ boost::shared_ptr<crocoddyl::CostModelResidual> CostModelFactory::create(
                 reference =
                     converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_cost + "reference"));
             } catch (const std::exception& e) {
-                MMPC_WARN << e.what() << " Set to the zero control vector";
+                EMPC_WARN << e.what() << " Set to the zero control vector";
                 reference = Eigen::VectorXd::Zero(nu);
             }
             if (reference.size() != nu) {

--- a/src/factory/cost.cpp
+++ b/src/factory/cost.cpp
@@ -42,7 +42,7 @@ boost::shared_ptr<crocoddyl::CostModelResidual> CostModelFactory::create(
                 reference =
                     converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_cost + "reference"));
             } catch (const std::exception& e) {
-                EMPC_WARN << e.what() << " Set to the zero state vector";
+                EMPC_DEBUG(e.what(), " Set to the zero state vector");
                 reference = state->zero();
             }
             if (reference.size() != state->get_nx()) {
@@ -61,7 +61,7 @@ boost::shared_ptr<crocoddyl::CostModelResidual> CostModelFactory::create(
                 reference =
                     converter<Eigen::VectorXd>::convert(server->getParam<std::string>(path_to_cost + "reference"));
             } catch (const std::exception& e) {
-                EMPC_WARN << e.what() << " Set to the zero control vector";
+                EMPC_DEBUG(e.what(), " Set to the zero control vector");
                 reference = Eigen::VectorXd::Zero(nu);
             }
             if (reference.size() != nu) {

--- a/src/mpc-controllers/carrot-mpc.cpp
+++ b/src/mpc-controllers/carrot-mpc.cpp
@@ -55,28 +55,29 @@ void CarrotMpc::loadCostParams()
     try {
         carrot_weight_ = params_server_->getParam<double>("mpc_controller/carrot_weight");
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/carrot_weight' has not been found in the parameters server. Set "
-               "to 10.0";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/carrot_weight' has not been found in the parameters server. Set "
+            "to 10.0");
         carrot_weight_ = 10.0;
     }
 
     try {
         carrot_tail_weight_ = params_server_->getParam<double>("mpc_controller/carrot_tail_weight");
     } catch (const std::exception& e) {
-        EMPC_WARN << "The following key: 'mpc_controller/carrot_tail_weight' has not been found in the parameters "
-                     "server. Set "
-                     "to 5.0";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/carrot_tail_weight' has not been found in the parameters "
+            "server. Set "
+            "to 5.0");
         carrot_tail_weight_ = 5.0;
     }
     try {
         carrot_tail_act_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/carrot_tail_act_weights"));
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/carrot_tail_act_weights' has not been found in the parameters "
-               "server. Set "
-               "to unitary vector";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/carrot_tail_act_weights' has not been found in the parameters "
+            "server. Set "
+            "to unitary vector");
         carrot_tail_act_weights_ = Eigen::VectorXd::Ones(robot_state_->get_ndx());
     }
     if (carrot_tail_act_weights_.size() != robot_state_->get_ndx()) {
@@ -88,20 +89,21 @@ void CarrotMpc::loadCostParams()
     try {
         control_reg_weight_ = params_server_->getParam<double>("mpc_controller/carrot_control_reg_weight");
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/carrot_control_reg_weight' has not been found in the parameters "
-               "server. Set "
-               "to 1e-2";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/carrot_control_reg_weight' has not been found in the parameters "
+            "server. Set "
+            "to 1e-2");
         control_reg_weight_ = 1e-2;
     }
     try {
         control_reg_act_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/carrot_control_reg_act_weights"));
     } catch (const std::exception& e) {
-        EMPC_WARN << "The following key: 'mpc_controller/carrot_control_reg_act_weights' has not been found in the "
-                     "parameters "
-                     "server. Set "
-                     "to unitary vector";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/carrot_control_reg_act_weights' has not been found in the "
+            "parameters "
+            "server. Set "
+            "to unitary vector");
         control_reg_act_weights_ = Eigen::VectorXd::Ones(actuation_->get_nu());
     }
     if (control_reg_act_weights_.size() != actuation_->get_nu()) {
@@ -113,18 +115,18 @@ void CarrotMpc::loadCostParams()
     try {
         state_reg_weight_ = params_server_->getParam<double>("mpc_controller/carrot_state_reg_weight");
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/carrot_state_reg_weight' has not been found in the parameters "
-               "server. Set to 1e-3";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/carrot_state_reg_weight' has not been found in the parameters "
+            "server. Set to 1e-3");
         state_reg_weight_ = 1e-3;
     }
     try {
         state_ref_act_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/carrot_state_ref_act_weights"));
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/carrot_state_ref_act_weights' has not been found in the parameters "
-               "server. Set to unitary vector";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/carrot_state_ref_act_weights' has not been found in the parameters "
+            "server. Set to unitary vector");
         state_ref_act_weights_ = Eigen::VectorXd::Ones(robot_state_->get_ndx());
     }
     if (state_ref_act_weights_.size() != robot_state_->get_ndx()) {
@@ -136,18 +138,19 @@ void CarrotMpc::loadCostParams()
     try {
         state_limits_weight_ = params_server_->getParam<double>("mpc_controller/carrot_state_limits_weight");
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/carrot_state_limits_weight' has not been found in the parameters "
-               "server. Set to 100";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/carrot_state_limits_weight' has not been found in the parameters "
+            "server. Set to 100");
         state_limits_weight_ = 100;
     }
     try {
         state_limits_act_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/carrot_state_limits_act_weights"));
     } catch (const std::exception& e) {
-        EMPC_WARN << "The following key: 'mpc_controller/carrot_state_limits_act_weights' has not been found in the "
-                     "parameters "
-                     "server. Set to unitary vector";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/carrot_state_limits_act_weights' has not been found in the "
+            "parameters "
+            "server. Set to unitary vector");
         state_limits_act_weights_ = Eigen::VectorXd::Ones(robot_state_->get_ndx());
     }
     if (state_limits_act_weights_.size() != robot_state_->get_ndx()) {
@@ -199,7 +202,7 @@ void CarrotMpc::createProblem()
                                                                                             costs);
                 break;
             case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics:
-                EMPC_ERROR << "Carrot with contact has not been implemented";
+                EMPC_ERROR("Carrot with contact has not been implemented");
                 break;
         }
 

--- a/src/mpc-controllers/carrot-mpc.cpp
+++ b/src/mpc-controllers/carrot-mpc.cpp
@@ -55,7 +55,7 @@ void CarrotMpc::loadCostParams()
     try {
         carrot_weight_ = params_server_->getParam<double>("mpc_controller/carrot_weight");
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/carrot_weight' has not been found in the parameters server. Set "
                "to 10.0";
         carrot_weight_ = 10.0;
@@ -64,7 +64,7 @@ void CarrotMpc::loadCostParams()
     try {
         carrot_tail_weight_ = params_server_->getParam<double>("mpc_controller/carrot_tail_weight");
     } catch (const std::exception& e) {
-        MMPC_WARN << "The following key: 'mpc_controller/carrot_tail_weight' has not been found in the parameters "
+        EMPC_WARN << "The following key: 'mpc_controller/carrot_tail_weight' has not been found in the parameters "
                      "server. Set "
                      "to 5.0";
         carrot_tail_weight_ = 5.0;
@@ -73,7 +73,7 @@ void CarrotMpc::loadCostParams()
         carrot_tail_act_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/carrot_tail_act_weights"));
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/carrot_tail_act_weights' has not been found in the parameters "
                "server. Set "
                "to unitary vector";
@@ -88,7 +88,7 @@ void CarrotMpc::loadCostParams()
     try {
         control_reg_weight_ = params_server_->getParam<double>("mpc_controller/carrot_control_reg_weight");
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/carrot_control_reg_weight' has not been found in the parameters "
                "server. Set "
                "to 1e-2";
@@ -98,7 +98,7 @@ void CarrotMpc::loadCostParams()
         control_reg_act_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/carrot_control_reg_act_weights"));
     } catch (const std::exception& e) {
-        MMPC_WARN << "The following key: 'mpc_controller/carrot_control_reg_act_weights' has not been found in the "
+        EMPC_WARN << "The following key: 'mpc_controller/carrot_control_reg_act_weights' has not been found in the "
                      "parameters "
                      "server. Set "
                      "to unitary vector";
@@ -113,7 +113,7 @@ void CarrotMpc::loadCostParams()
     try {
         state_reg_weight_ = params_server_->getParam<double>("mpc_controller/carrot_state_reg_weight");
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/carrot_state_reg_weight' has not been found in the parameters "
                "server. Set to 1e-3";
         state_reg_weight_ = 1e-3;
@@ -122,7 +122,7 @@ void CarrotMpc::loadCostParams()
         state_ref_act_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/carrot_state_ref_act_weights"));
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/carrot_state_ref_act_weights' has not been found in the parameters "
                "server. Set to unitary vector";
         state_ref_act_weights_ = Eigen::VectorXd::Ones(robot_state_->get_ndx());
@@ -136,7 +136,7 @@ void CarrotMpc::loadCostParams()
     try {
         state_limits_weight_ = params_server_->getParam<double>("mpc_controller/carrot_state_limits_weight");
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/carrot_state_limits_weight' has not been found in the parameters "
                "server. Set to 100";
         state_limits_weight_ = 100;
@@ -145,7 +145,7 @@ void CarrotMpc::loadCostParams()
         state_limits_act_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/carrot_state_limits_act_weights"));
     } catch (const std::exception& e) {
-        MMPC_WARN << "The following key: 'mpc_controller/carrot_state_limits_act_weights' has not been found in the "
+        EMPC_WARN << "The following key: 'mpc_controller/carrot_state_limits_act_weights' has not been found in the "
                      "parameters "
                      "server. Set to unitary vector";
         state_limits_act_weights_ = Eigen::VectorXd::Ones(robot_state_->get_ndx());
@@ -199,7 +199,7 @@ void CarrotMpc::createProblem()
                                                                                             costs);
                 break;
             case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics:
-                MMPC_ERROR << "Carrot with contact has not been implemented";
+                EMPC_ERROR << "Carrot with contact has not been implemented";
                 break;
         }
 

--- a/src/mpc-controllers/rail-mpc.cpp
+++ b/src/mpc-controllers/rail-mpc.cpp
@@ -24,7 +24,7 @@ RailMpc::RailMpc(const std::vector<Eigen::VectorXd>& state_ref, const std::size_
     try {
         state_weight_ = params_server_->getParam<double>("mpc_controller/rail_weight");
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/rail_weight' has not been found in the parameters server. Set "
                "to 10.0";
         state_weight_ = 10;
@@ -34,7 +34,7 @@ RailMpc::RailMpc(const std::vector<Eigen::VectorXd>& state_ref, const std::size_
         state_activation_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/rail_activation_weights"));
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/rail_activation_weights' has not been found in the parameters "
                "server. Set "
                "to unitary vector";
@@ -49,7 +49,7 @@ RailMpc::RailMpc(const std::vector<Eigen::VectorXd>& state_ref, const std::size_
     try {
         control_weight_ = params_server_->getParam<double>("mpc_controller/rail_control_weight");
     } catch (const std::exception& e) {
-        MMPC_WARN << "The following key: 'mpc_controller/rail_control_weight' has not been found in the parameters "
+        EMPC_WARN << "The following key: 'mpc_controller/rail_control_weight' has not been found in the parameters "
                      "server. Set "
                      "to 1e-1";
         control_weight_ = 1e-1;
@@ -83,7 +83,7 @@ void RailMpc::createProblem()
                                                                                             costs);
                 break;
             case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics:
-                MMPC_ERROR << "Carrot with contact has not been implemented";
+                EMPC_ERROR << "Carrot with contact has not been implemented";
                 break;
         }
 

--- a/src/mpc-controllers/rail-mpc.cpp
+++ b/src/mpc-controllers/rail-mpc.cpp
@@ -24,9 +24,9 @@ RailMpc::RailMpc(const std::vector<Eigen::VectorXd>& state_ref, const std::size_
     try {
         state_weight_ = params_server_->getParam<double>("mpc_controller/rail_weight");
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/rail_weight' has not been found in the parameters server. Set "
-               "to 10.0";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/rail_weight' has not been found in the parameters server. Set "
+            "to 10.0");
         state_weight_ = 10;
     }
 
@@ -34,10 +34,10 @@ RailMpc::RailMpc(const std::vector<Eigen::VectorXd>& state_ref, const std::size_
         state_activation_weights_ = converter<Eigen::VectorXd>::convert(
             params_server_->getParam<std::string>("mpc_controller/rail_activation_weights"));
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/rail_activation_weights' has not been found in the parameters "
-               "server. Set "
-               "to unitary vector";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/rail_activation_weights' has not been found in the parameters "
+            "server. Set "
+            "to unitary vector");
         state_activation_weights_ = Eigen::VectorXd::Ones(robot_state_->get_ndx());
     }
     if (state_activation_weights_.size() != robot_state_->get_ndx()) {
@@ -49,9 +49,10 @@ RailMpc::RailMpc(const std::vector<Eigen::VectorXd>& state_ref, const std::size_
     try {
         control_weight_ = params_server_->getParam<double>("mpc_controller/rail_control_weight");
     } catch (const std::exception& e) {
-        EMPC_WARN << "The following key: 'mpc_controller/rail_control_weight' has not been found in the parameters "
-                     "server. Set "
-                     "to 1e-1";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/rail_control_weight' has not been found in the parameters "
+            "server. Set "
+            "to 1e-1");
         control_weight_ = 1e-1;
     }
     createProblem();
@@ -83,7 +84,7 @@ void RailMpc::createProblem()
                                                                                             costs);
                 break;
             case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics:
-                EMPC_ERROR << "Carrot with contact has not been implemented";
+                EMPC_ERROR("Carrot with contact has not been implemented");
                 break;
         }
 

--- a/src/mpc-controllers/weighted-mpc.cpp
+++ b/src/mpc-controllers/weighted-mpc.cpp
@@ -21,36 +21,38 @@ WeightedMpc::WeightedMpc(const boost::shared_ptr<Trajectory>& trajectory,
     try {
         alpha_ = params_server_->getParam<double>("mpc_controller/weighted_alpha");
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/weighted_alpha' has not been found in the parameters server. Set "
-               "to 20.0";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/weighted_alpha' has not been found in the parameters server. Set "
+            "to 20.0");
         alpha_ = 20.0;
     }
 
     try {
         beta_ = params_server_->getParam<double>("mpc_controller/weighted_beta");
     } catch (const std::exception& e) {
-        EMPC_WARN
-            << "The following key: 'mpc_controller/weighted_beta' has not been found in the parameters server. Set "
-               "to 1.0";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/weighted_beta' has not been found in the parameters server. Set "
+            "to 1.0");
         beta_ = 1.0;
     }
 
     try {
         state_reg_ = params_server_->getParam<double>("mpc_controller/weighted_state_reg");
     } catch (const std::exception& e) {
-        EMPC_WARN << "The following key: 'mpc_controller/weighted_state_reg' has not been found in the parameters "
-                     "server. Set "
-                     "to 1e-1";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/weighted_state_reg' has not been found in the parameters "
+            "server. Set "
+            "to 1e-1");
         state_reg_ = 1e-1;
     }
 
     try {
         control_reg_ = params_server_->getParam<double>("mpc_controller/weighted_control_reg");
     } catch (const std::exception& e) {
-        EMPC_WARN << "The following key: 'mpc_controller/weighted_control_reg' has not been found in the parameters "
-                     "server. Set "
-                     "to 1e-1";
+        EMPC_DEBUG(
+            "The following key: 'mpc_controller/weighted_control_reg' has not been found in the parameters "
+            "server. Set "
+            "to 1e-1");
         control_reg_ = 1e-1;
     }
 
@@ -99,7 +101,7 @@ void WeightedMpc::createProblem()
                                                                                             costs);
                 break;
             case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics:
-                EMPC_ERROR << "Weighted with contact has not been implemented";
+                EMPC_ERROR("Weighted with contact has not been implemented");
                 break;
         }
 

--- a/src/mpc-controllers/weighted-mpc.cpp
+++ b/src/mpc-controllers/weighted-mpc.cpp
@@ -21,7 +21,7 @@ WeightedMpc::WeightedMpc(const boost::shared_ptr<Trajectory>& trajectory,
     try {
         alpha_ = params_server_->getParam<double>("mpc_controller/weighted_alpha");
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/weighted_alpha' has not been found in the parameters server. Set "
                "to 20.0";
         alpha_ = 20.0;
@@ -30,7 +30,7 @@ WeightedMpc::WeightedMpc(const boost::shared_ptr<Trajectory>& trajectory,
     try {
         beta_ = params_server_->getParam<double>("mpc_controller/weighted_beta");
     } catch (const std::exception& e) {
-        MMPC_WARN
+        EMPC_WARN
             << "The following key: 'mpc_controller/weighted_beta' has not been found in the parameters server. Set "
                "to 1.0";
         beta_ = 1.0;
@@ -39,7 +39,7 @@ WeightedMpc::WeightedMpc(const boost::shared_ptr<Trajectory>& trajectory,
     try {
         state_reg_ = params_server_->getParam<double>("mpc_controller/weighted_state_reg");
     } catch (const std::exception& e) {
-        MMPC_WARN << "The following key: 'mpc_controller/weighted_state_reg' has not been found in the parameters "
+        EMPC_WARN << "The following key: 'mpc_controller/weighted_state_reg' has not been found in the parameters "
                      "server. Set "
                      "to 1e-1";
         state_reg_ = 1e-1;
@@ -48,7 +48,7 @@ WeightedMpc::WeightedMpc(const boost::shared_ptr<Trajectory>& trajectory,
     try {
         control_reg_ = params_server_->getParam<double>("mpc_controller/weighted_control_reg");
     } catch (const std::exception& e) {
-        MMPC_WARN << "The following key: 'mpc_controller/weighted_control_reg' has not been found in the parameters "
+        EMPC_WARN << "The following key: 'mpc_controller/weighted_control_reg' has not been found in the parameters "
                      "server. Set "
                      "to 1e-1";
         control_reg_ = 1e-1;
@@ -99,7 +99,7 @@ void WeightedMpc::createProblem()
                                                                                             costs);
                 break;
             case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics:
-                MMPC_ERROR << "Weighted with contact has not been implemented";
+                EMPC_ERROR << "Weighted with contact has not been implemented";
                 break;
         }
 

--- a/src/multicopter-base-params.cpp
+++ b/src/multicopter-base-params.cpp
@@ -38,7 +38,7 @@ void MultiCopterBaseParams::autoSetup(const std::string&                     pat
         base_link_name_ = server->getParam<std::string>(path_to_platform + "base_link_name");
         n_rotors_       = server->getParam<int>(path_to_platform + "n_rotors");
 
-        MMPC_INFO << "Number of rotors: " << n_rotors_;
+        EMPC_INFO << "Number of rotors: " << n_rotors_;
         
         std::vector<std::string> rotors = server->getParam<std::vector<std::string>>(path_to_platform + "rotors");
         if (n_rotors_ != rotors.size()) {

--- a/src/multicopter-base-params.cpp
+++ b/src/multicopter-base-params.cpp
@@ -38,8 +38,8 @@ void MultiCopterBaseParams::autoSetup(const std::string&                     pat
         base_link_name_ = server->getParam<std::string>(path_to_platform + "base_link_name");
         n_rotors_       = server->getParam<int>(path_to_platform + "n_rotors");
 
-        EMPC_INFO << "Number of rotors: " << n_rotors_;
-        
+        EMPC_INFO("Number of rotors: ", n_rotors_);
+
         std::vector<std::string> rotors = server->getParam<std::vector<std::string>>(path_to_platform + "rotors");
         if (n_rotors_ != rotors.size()) {
             throw std::runtime_error("'n_rotors' field and the number of rotor poses specified must be the same.");

--- a/src/sbfddp.cpp
+++ b/src/sbfddp.cpp
@@ -50,7 +50,7 @@ IntegratedActionModelTypes SolverSbFDDP::getIntegratedModelType(
             return IntegratedActionModelTypes::IntegratedActionModelRK4;
         }
     }
-    MMPC_ERROR << "Integrated action type not found";
+    EMPC_ERROR << "Integrated action type not found";
     return IntegratedActionModelTypes::NbIntegratedActionModelTypes;
 }
 
@@ -66,7 +66,7 @@ DifferentialActionModelTypes SolverSbFDDP::getDifferentialModelType(
             return DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics;
         }
     }
-    MMPC_ERROR << "Differential action type not found";
+    EMPC_ERROR << "Differential action type not found";
     return DifferentialActionModelTypes::NbDifferentialActionModelTypes;
 }
 
@@ -114,7 +114,7 @@ IntegratedActionModelTypes SolverSbFDDP::getIntegratedDataType(
             return IntegratedActionModelTypes::IntegratedActionModelRK4;
         }
     }
-    MMPC_ERROR << "Integrated action data type not found";
+    EMPC_ERROR << "Integrated action data type not found";
     return IntegratedActionModelTypes::NbIntegratedActionModelTypes;
 }
 
@@ -130,7 +130,7 @@ DifferentialActionModelTypes SolverSbFDDP::getDifferentialDataType(
             return DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics;
         }
     }
-    MMPC_ERROR << "Differential action data type not found";
+    EMPC_ERROR << "Differential action data type not found";
     return DifferentialActionModelTypes::NbDifferentialActionModelTypes;
 }
 

--- a/src/sbfddp.cpp
+++ b/src/sbfddp.cpp
@@ -50,7 +50,7 @@ IntegratedActionModelTypes SolverSbFDDP::getIntegratedModelType(
             return IntegratedActionModelTypes::IntegratedActionModelRK4;
         }
     }
-    EMPC_ERROR << "Integrated action type not found";
+    EMPC_ERROR("Integrated action type not found");
     return IntegratedActionModelTypes::NbIntegratedActionModelTypes;
 }
 
@@ -66,7 +66,7 @@ DifferentialActionModelTypes SolverSbFDDP::getDifferentialModelType(
             return DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics;
         }
     }
-    EMPC_ERROR << "Differential action type not found";
+    EMPC_ERROR("Differential action type not found");
     return DifferentialActionModelTypes::NbDifferentialActionModelTypes;
 }
 
@@ -114,7 +114,7 @@ IntegratedActionModelTypes SolverSbFDDP::getIntegratedDataType(
             return IntegratedActionModelTypes::IntegratedActionModelRK4;
         }
     }
-    EMPC_ERROR << "Integrated action data type not found";
+    EMPC_ERROR("Integrated action data type not found");
     return IntegratedActionModelTypes::NbIntegratedActionModelTypes;
 }
 
@@ -130,7 +130,7 @@ DifferentialActionModelTypes SolverSbFDDP::getDifferentialDataType(
             return DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics;
         }
     }
-    EMPC_ERROR << "Differential action data type not found";
+    EMPC_ERROR("Differential action data type not found");
     return DifferentialActionModelTypes::NbDifferentialActionModelTypes;
 }
 

--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -43,10 +43,10 @@ void Stage::autoSetup(const std::string&                        path_to_stages,
                 path_to_stage + "contacts/" + contact_name + "/", server, shared_from_this(), contact_type);
             contacts_->addContact(contact_name, contact);
             contact_types_.insert({contact_name, contact_type});
-            MMPC_INFO << "Stage '" << name_ << "': added contact '" << contact_name << "'";
+            EMPC_INFO << "Stage '" << name_ << "': added contact '" << contact_name << "'";
         }
     } catch (const std::exception& e) {
-        MMPC_INFO << "Stage: " << name_ << " DOES NOT HAVE contacts";
+        EMPC_INFO << "Stage: " << name_ << " DOES NOT HAVE contacts";
     }
 
     std::vector<std::string> cost_names = converter<std::vector<std::string>>::convert(stage.at("costs"));
@@ -56,7 +56,7 @@ void Stage::autoSetup(const std::string&                        path_to_stages,
         try {
             server->getParam<double>(path_to_stage + "costs/" + cost_name + "/active");
         } catch (const std::exception& e) {
-            MMPC_WARN << e.what() << " Set to true.";
+            EMPC_WARN << e.what() << " Set to true.";
             active = true;
         }
         CostModelTypes                                  cost_type;
@@ -66,7 +66,7 @@ void Stage::autoSetup(const std::string&                        path_to_stages,
         costs_->addCost(cost_name, cost, weight, active);
         cost_types_.insert({cost_name, cost_type});
 
-        MMPC_INFO << "Stage '" << name_ << "': added cost '" << cost_name << "'";
+        EMPC_INFO << "Stage '" << name_ << "': added cost '" << cost_name << "'";
     }
 }
 

--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -43,10 +43,10 @@ void Stage::autoSetup(const std::string&                        path_to_stages,
                 path_to_stage + "contacts/" + contact_name + "/", server, shared_from_this(), contact_type);
             contacts_->addContact(contact_name, contact);
             contact_types_.insert({contact_name, contact_type});
-            EMPC_INFO << "Stage '" << name_ << "': added contact '" << contact_name << "'";
+            EMPC_DEBUG("Stage ", name_, ": added contact ", contact_name);
         }
     } catch (const std::exception& e) {
-        EMPC_INFO << "Stage: " << name_ << " DOES NOT HAVE contacts";
+        EMPC_DEBUG("Stage: ", name_, " DOES NOT HAVE contacts");
     }
 
     std::vector<std::string> cost_names = converter<std::vector<std::string>>::convert(stage.at("costs"));
@@ -56,7 +56,7 @@ void Stage::autoSetup(const std::string&                        path_to_stages,
         try {
             server->getParam<double>(path_to_stage + "costs/" + cost_name + "/active");
         } catch (const std::exception& e) {
-            EMPC_WARN << e.what() << " Set to true.";
+            EMPC_DEBUG(e.what(), " Set to true.");
             active = true;
         }
         CostModelTypes                                  cost_type;
@@ -66,7 +66,7 @@ void Stage::autoSetup(const std::string&                        path_to_stages,
         costs_->addCost(cost_name, cost, weight, active);
         cost_types_.insert({cost_name, cost_type});
 
-        EMPC_INFO << "Stage '" << name_ << "': added cost '" << cost_name << "'";
+        EMPC_DEBUG("Stage ", name_, ": added cost ", cost_name);
     }
 }
 

--- a/src/trajectory.cpp
+++ b/src/trajectory.cpp
@@ -41,7 +41,7 @@ void Trajectory::autoSetup(const std::string& yaml_path)
         problem_params_.use_squash = false;
         problem_params_.dt         = 0;
         problem_params_.integrator = "";
-        EMPC_WARN << "Problem params not found. If not in the Yaml file, specify when call createProblem()";
+        EMPC_DEBUG("Problem params not found. If not in the Yaml file, specify when call createProblem()");
     }
 
     robot_state_ = boost::make_shared<crocoddyl::StateMultibody>(robot_model_);
@@ -55,7 +55,7 @@ void Trajectory::autoSetup(const std::string& yaml_path)
         initial_state_ = params_server_->getParam<Eigen::VectorXd>("initial_state");
     } catch (const std::exception& e) {
         initial_state_ = robot_state_->zero();
-        EMPC_WARN << "Initial state not found, set to the zero state";
+        EMPC_DEBUG("Initial state not found, set to the zero state");
     }
 
     if (initial_state_.size() != robot_state_->get_nx()) {
@@ -86,6 +86,9 @@ void Trajectory::autoSetup(const std::string& yaml_path)
         }
     }
     duration_ = time;
+    EMPC_ERROR("This is an error message ", 213);
+    EMPC_WARN("This is an warn message ", 213);
+    EMPC_INFO("This is an info message ", 213);
 }
 
 boost::shared_ptr<crocoddyl::ShootingProblem> Trajectory::createProblem() const
@@ -103,7 +106,7 @@ boost::shared_ptr<crocoddyl::ShootingProblem> Trajectory::createProblem(const st
                                                                         const bool&        squash,
                                                                         const std::string& integration_method) const
 {
-    EMPC_INFO << "Creating problem for the given stages. Contact Trajectory = " << has_contact_;
+    EMPC_INFO("Creating problem for the given stages. Contact Trajectory = ", has_contact_);
     std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract>> running_models;
     boost::shared_ptr<crocoddyl::ActionModelAbstract>              terminal_model;
 
@@ -126,7 +129,7 @@ boost::shared_ptr<crocoddyl::ShootingProblem> Trajectory::createProblem(const st
             last_duration0 = false;
         }
 
-        EMPC_INFO << "Create Problem; " << (*stage)->get_name() << ", # Knots: " << n_knots;
+        EMPC_INFO("Create Problem; ", (*stage)->get_name(), "# Knots: ", n_knots);
 
         iam->set_u_lb(platform_params_->u_lb);
         iam->set_u_ub(platform_params_->u_ub);

--- a/src/trajectory.cpp
+++ b/src/trajectory.cpp
@@ -41,7 +41,7 @@ void Trajectory::autoSetup(const std::string& yaml_path)
         problem_params_.use_squash = false;
         problem_params_.dt         = 0;
         problem_params_.integrator = "";
-        MMPC_WARN << "Problem params not found. If not in the Yaml file, specify when call createProblem()";
+        EMPC_WARN << "Problem params not found. If not in the Yaml file, specify when call createProblem()";
     }
 
     robot_state_ = boost::make_shared<crocoddyl::StateMultibody>(robot_model_);
@@ -55,7 +55,7 @@ void Trajectory::autoSetup(const std::string& yaml_path)
         initial_state_ = params_server_->getParam<Eigen::VectorXd>("initial_state");
     } catch (const std::exception& e) {
         initial_state_ = robot_state_->zero();
-        MMPC_WARN << "Initial state not found, set to the zero state";
+        EMPC_WARN << "Initial state not found, set to the zero state";
     }
 
     if (initial_state_.size() != robot_state_->get_nx()) {
@@ -103,7 +103,7 @@ boost::shared_ptr<crocoddyl::ShootingProblem> Trajectory::createProblem(const st
                                                                         const bool&        squash,
                                                                         const std::string& integration_method) const
 {
-    MMPC_INFO << "Creating problem for the given stages. Contact Trajectory = " << has_contact_;
+    EMPC_INFO << "Creating problem for the given stages. Contact Trajectory = " << has_contact_;
     std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract>> running_models;
     boost::shared_ptr<crocoddyl::ActionModelAbstract>              terminal_model;
 
@@ -126,7 +126,7 @@ boost::shared_ptr<crocoddyl::ShootingProblem> Trajectory::createProblem(const st
             last_duration0 = false;
         }
 
-        MMPC_INFO << "Create Problem; " << (*stage)->get_name() << ", # Knots: " << n_knots;
+        EMPC_INFO << "Create Problem; " << (*stage)->get_name() << ", # Knots: " << n_knots;
 
         iam->set_u_lb(platform_params_->u_lb);
         iam->set_u_ub(platform_params_->u_ub);

--- a/src/utils/parser_yaml.cpp
+++ b/src/utils/parser_yaml.cpp
@@ -343,7 +343,7 @@ void ParserYaml::parseFreely()
 YAML::Node ParserYaml::loadYaml(std::string file_path)
 {
     try {
-        MMPC_INFO << "Parsing " << file_path;
+        EMPC_INFO << "Parsing " << file_path;
         return YAML::LoadFile(file_path);
     } catch (YAML::BadFile& e) {
         throw std::runtime_error("Couldn't load file: " + file_path);
@@ -436,7 +436,7 @@ void ParserYaml::walkTreeRecursive(YAML::Node node, std::vector<std::string>& no
         case YAML::NodeType::Null:
             break;
         default:
-            MMPC_ERROR << "Unsupported node Type at walkTreeR.";
+            EMPC_ERROR << "Unsupported node Type at walkTreeR.";
             break;
     }
 }

--- a/src/utils/parser_yaml.cpp
+++ b/src/utils/parser_yaml.cpp
@@ -343,7 +343,7 @@ void ParserYaml::parseFreely()
 YAML::Node ParserYaml::loadYaml(std::string file_path)
 {
     try {
-        EMPC_INFO << "Parsing " << file_path;
+        EMPC_INFO("Parsing ", file_path);
         return YAML::LoadFile(file_path);
     } catch (YAML::BadFile& e) {
         throw std::runtime_error("Couldn't load file: " + file_path);
@@ -436,7 +436,7 @@ void ParserYaml::walkTreeRecursive(YAML::Node node, std::vector<std::string>& no
         case YAML::NodeType::Null:
             break;
         default:
-            EMPC_ERROR << "Unsupported node Type at walkTreeR.";
+            EMPC_ERROR("Unsupported node Type at walkTreeR.");
             break;
     }
 }

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -6,6 +6,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "eagle_mpc/utils/tools.hpp"
+#include "eagle_mpc/utils/log.hpp"
 
 namespace eagle_mpc
 {
@@ -27,4 +28,6 @@ void Tools::thrustToSpeedNormalized(const Eigen::VectorXd&                      
     speed = (thrust.array() / params->cf_).sqrt();
     speed = -1.0 + 2 * (speed.array() - params->min_prop_speed_) / (params->max_prop_speed_ - params->min_prop_speed_);
 }
+
+void log(){}
 }  // namespace eagle_mpc


### PR DESCRIPTION
This PR adds log macros whose appearance can be chosen in compile time. It defines several levels:
- 0: only error messages
- 1: error & warn
- 2: error, warn & info

Separately you can now activate and deactivate debug messages. All yaml parsing messages have been transformed to be debug messages.

Also, it removes duplicated crocoddyl binding exposed objects 